### PR TITLE
fix broken satori go-uuid api

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -83,8 +83,9 @@ func (a *Adapter) LoadPolicy(model model.Model) {
 }
 
 func savePolicyLine(ptype string, rule []string) CasbinRule {
+	id, _ := uuid.NewV4()
 	line := CasbinRule{
-		ID: uuid.NewV4().String(),
+		ID: id.String(),
 	}
 
 	line.PType = ptype


### PR DESCRIPTION
go-uuid package changed the api; as a result this package does not build. This pr fixes the compilation issue. 